### PR TITLE
Fixed code for R 4.5.1

### DIFF
--- a/server.R
+++ b/server.R
@@ -1,4 +1,3 @@
-
 server <- function(input, output, session) {
   
   choose_data <- callModule(xap.chooseDataTable, "choose_data")
@@ -91,6 +90,14 @@ server <- function(input, output, session) {
       output[[paste0("dt", nam[i])]] <- renderDataTable(s[[i]]$dt)
       create_modal(s[[i]], nam[i])
     })
+  })
+  
+  observeEvent(input$link, {
+    showModal(modalDialog(
+      DT::dataTableOutput("dt"),
+      size = "l",
+      easyClose = TRUE
+    ))
   })
 }
 

--- a/ui.R
+++ b/ui.R
@@ -1,5 +1,3 @@
-
-
 tables <- xap.list_tables()
 
 ui <- fluidPage(
@@ -31,7 +29,7 @@ ui <- fluidPage(
             )
           )
         ),
-        bsModal("modal", "Plot", "link", size = "large", dataTableOutput("dt")),
+        uiOutput("modal_ui"),
         uiOutput("t"),
         uiOutput("modals"),
         uiOutput("plot_modals")


### PR DESCRIPTION
The preview modal didn't work with R 4.5.1. 

The issue is with the modal (bsModal) containing dataTableOutput("dt"). In R 4.5.1 (and recent Shiny/DT versions), DataTables inside Bootstrap modals often do not render or expand correctly..

The fix uses Shiny's native modal, which is more robust in recent versions.